### PR TITLE
Fix adversary browser create button

### DIFF
--- a/src/components/panels/RightPanel.jsx
+++ b/src/components/panels/RightPanel.jsx
@@ -30,7 +30,7 @@ const RightPanel = ({
   onApplyStressChange,
   onExitEditMode
 }) => {
-  if (showMockup) {
+  if (showMockup && rightColumnMode === null) {
     return (
       <PanelShell className="right-panel-shell">
         <div className="creator-header">


### PR DESCRIPTION
Fix: Ensure the new creator opens when clicking 'Create' in the adversary browser, even if the mockup toggle is enabled.

Previously, the `showMockup` state in the `RightPanel` component would unconditionally display the old `AdversaryCreatorMockup` if true, overriding the intended behavior of opening the new `Creator` component when `rightColumnMode` was set to 'creator'. This change ensures the mockup only displays when `showMockup` is true and no other panel mode is active.

---
<a href="https://cursor.com/background-agent?bcId=bc-34f286de-1917-4bcd-96f1-cff8f18acb79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-34f286de-1917-4bcd-96f1-cff8f18acb79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

