### PR TITLE
Refine sort/group: group labels above cards, direction toggle

### DIFF
--- a/src/components/Dashboard/DashboardView.jsx
+++ b/src/components/Dashboard/DashboardView.jsx
@@ -57,7 +57,7 @@ const DashboardContent = () => {
   const [rightColumnMode, setRightColumnMode] = useState('browser') // 'browser' | 'info' | 'receipt'
   const [sortGroupOpen, setSortGroupOpen] = useState(false)
   const sortGroupButtonRef = useRef(null)
-  const { sortBy, groupBy, setSortBy, setGroupBy } = useDashboardSortGroup()
+  const { sortBy, sortDir, groupBy, setSortBy, setGroupBy } = useDashboardSortGroup()
 
   // Narrow screen detection for NavRail placement
   const [isNarrow, setIsNarrow] = useState(false)
@@ -90,7 +90,7 @@ const DashboardContent = () => {
 
   const smoothScrollTo = useSmoothScroll(scrollContainerRef)
 
-  const { entityGroups, getEntityGroups } = useEntityGroups(adversaryGroups, countdowns, sortBy, groupBy)
+  const { entityGroups, getEntityGroups } = useEntityGroups(adversaryGroups, countdowns, sortBy, sortDir, groupBy)
 
   const openRightColumn = useCallback((mode) => {
     setRightColumnMode(mode)
@@ -490,7 +490,7 @@ selectedCustomAdversaryId={selectedCustomAdversaryId}
           placement={navPlacement}
           activeId={navActiveId}
           onAction={handleNavAction}
-          sortActive={groupBy !== 'none' || sortBy !== 'name-asc'}
+          sortActive={groupBy !== 'none' || sortBy !== 'name' || sortDir !== 'asc'}
           sortButtonRef={sortGroupButtonRef}
           onSortToggle={() => setSortGroupOpen(v => !v)}
         />
@@ -500,6 +500,7 @@ selectedCustomAdversaryId={selectedCustomAdversaryId}
           anchorRef={sortGroupButtonRef}
           placement={navPlacement}
           sortBy={sortBy}
+          sortDir={sortDir}
           groupBy={groupBy}
           onSortBy={setSortBy}
           onGroupBy={setGroupBy}

--- a/src/components/Dashboard/EntityColumns.jsx
+++ b/src/components/Dashboard/EntityColumns.jsx
@@ -1,7 +1,30 @@
-import React from 'react'
+import React, { useEffect, useRef, useCallback } from 'react'
 import Panel from './Panels'
 import GameCard from '../Adversaries/GameCard'
 import { DASHBOARD_GAP } from './constants'
+
+// Collect consecutive adversary entries with the same groupName into sections.
+function buildSections(entityGroups) {
+  const sections = []
+  let i = 0
+  while (i < entityGroups.length) {
+    const g = entityGroups[i]
+    if (g.groupName && g.type === 'adversary') {
+      const entries = [g]
+      let j = i + 1
+      while (j < entityGroups.length && entityGroups[j].groupName === g.groupName && entityGroups[j].type === 'adversary') {
+        entries.push(entityGroups[j])
+        j++
+      }
+      sections.push({ type: 'grouped', groupName: g.groupName, entries, startFlatIndex: i })
+      i = j
+    } else {
+      sections.push({ type: 'solo', entry: g, flatIndex: i })
+      i++
+    }
+  }
+  return sections
+}
 
 const EntityColumns = ({
   entityGroups,
@@ -30,374 +53,367 @@ const EntityColumns = ({
   setSpacerShrinking,
   onOpenBrowser,
 }) => {
-  return (
-    <div ref={scrollContainerRef} className="dashboard-scroll-container" onScroll={onScroll}>
-      {entityGroups.length === 0
-        ? null
-        : (() => {
-            const items = []
+  const isGrouped = entityGroups.some(g => g.groupName)
+  // Map of sectionKey → { el (label DOM node), startFlatIndex, count }
+  const labelInfoRef = useRef({})
 
-            entityGroups.forEach((group, index) => {
-              const isSpacerPosition =
-                removingCardSpacer && removingCardSpacer.baseName === group.baseName && group.type === 'adversary'
+  // Reposition all group labels so each is centered over its visible cards.
+  // Called on scroll and whenever layout changes (columns, entityGroups).
+  const updateLabelPositions = useCallback(() => {
+    const container = scrollContainerRef.current
+    if (!container) return
+    const viewportLeft = container.scrollLeft
+    const viewportRight = viewportLeft + container.clientWidth
 
-              if (isSpacerPosition) {
-                items.push(
-                  <Panel
-                    key={`spacer-${removingCardSpacer.baseName}`}
-                    style={{
-                      width: spacerShrinking ? '0px' : `${columnWidth}px`,
-                      flexShrink: 0,
-                      flexGrow: 0,
-                      flex: 'none',
-                      paddingRight: '0',
-                      paddingTop: spacerShrinking ? '0px' : `${DASHBOARD_GAP}px`,
-                      paddingBottom: spacerShrinking ? '0px' : `${DASHBOARD_GAP}px`,
-                      scrollSnapAlign: 'none',
-                      overflow: 'hidden',
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'stretch',
-                      height: '100%',
-                      opacity: 0,
-                      transition: 'width 0.3s ease, padding-top 0.3s ease, padding-bottom 0.3s ease',
-                    }}
-                  />,
-                )
-                return
-              }
+    Object.values(labelInfoRef.current).forEach(({ el, startFlatIndex, count }) => {
+      if (!el) return
+      const groupStart = DASHBOARD_GAP + startFlatIndex * (columnWidth + DASHBOARD_GAP)
+      const groupWidth = count * columnWidth + (count - 1) * DASHBOARD_GAP
+      const groupEnd = groupStart + groupWidth
 
-              items.push(
-                <Panel
-                  key={group.type === 'adversary' ? `adversary-${group.template?.id || group.baseName}` : `${group.type}-${group.baseName}`}
-                  className={
-                    index === 0
-                      ? 'dashboard-column dashboard-column--first'
-                      : index === entityGroups.length - 1
-                      ? 'dashboard-column dashboard-column--last'
-                      : 'dashboard-column'
-                  }
-                  style={{
-                    width: `${columnWidth}px`,
-                    flexShrink: 0,
-                    flexGrow: 0,
-                    flex: 'none',
-                    paddingRight: '0',
-                    paddingTop: `${DASHBOARD_GAP}px`,
-                    paddingBottom: `${DASHBOARD_GAP}px`,
-                    scrollSnapAlign: 'start',
-                    overflow: group.type === 'adversary' ? 'visible' : 'hidden',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'stretch',
-                    height: 'auto',
-                    opacity: newCards.has(`${group.type}-${group.baseName}`) ? 0 : 1,
-                    transition: 'opacity 0.2s ease',
-                  }}
-                >
-                  {group.groupLabel && (
-                    <div style={{
-                      fontSize: '0.65rem',
-                      fontWeight: 700,
-                      letterSpacing: '0.1em',
-                      textTransform: 'uppercase',
-                      color: 'var(--text-secondary)',
-                      padding: '0 2px 6px',
-                      userSelect: 'none',
-                    }}>
-                      {group.groupLabel}
-                    </div>
-                  )}
-                  <GameCard
-                    type={group.type}
-                    item={
-                      group.type === 'adversary'
-                        ? { ...group.template, name: group.baseName, hp: 0, stress: 0, isDead: false }
-                        : { ...group.instances[0], name: group.instances[0]?.name || group.baseName }
-                    }
-                    mode="expanded"
-                    instances={
-                      group.type === 'adversary'
-                        ? [...group.instances]
-                            .sort((a, b) => (a.duplicateNumber || 1) - (b.duplicateNumber || 1))
-                            .map((inst) => ({
-                              ...inst,
-                              hpMax: group.template.hpMax,
-                              stressMax: group.template.stressMax,
-                            }))
-                        : group.instances
-                    }
-                    showCustomCreator={
-                      group.type === 'adversary' && editingAdversaryId && group.instances.some((i) => i.id === editingAdversaryId)
-                    }
-                    onSaveCustomAdversary={
-                      group.type === 'adversary' && editingAdversaryId && group.instances.some((i) => i.id === editingAdversaryId)
-                        ? handleSaveCustomAdversary
-                        : undefined
-                    }
-                    onCancelEdit={
-                      group.type === 'adversary' && editingAdversaryId && group.instances.some((i) => i.id === editingAdversaryId)
-                        ? handleCancelEdit
-                        : undefined
-                    }
-                    isStockAdversary={
-                      group.type === 'adversary' && editingAdversaryId && group.instances.some((i) => i.id === editingAdversaryId)
-                        ? !group.template?.source || group.template?.source !== 'Homebrew'
-                        : false
-                    }
-                    onApplyDamage={
-                      group.type === 'adversary'
-                        ? (id, damage) => {
-                            const instance = group.instances.find((i) => i.id === id)
-                            if (instance) {
-                              updateAdversary(id, { hp: Math.min(group.template.hpMax || 1, (instance.hp || 0) + damage) })
-                            }
-                          }
-                        : undefined
-                    }
-                    onApplyHealing={
-                      group.type === 'adversary'
-                        ? (id, healing) => {
-                            const instance = group.instances.find((i) => i.id === id)
-                            if (instance) {
-                              updateAdversary(id, { hp: Math.max(0, (instance.hp || 0) - healing) })
-                            }
-                          }
-                        : undefined
-                    }
-                    onApplyStressChange={
-                      group.type === 'adversary'
-                        ? (id, stress) => {
-                            const instance = group.instances.find((i) => i.id === id)
-                            if (instance) {
-                              updateAdversary(id, {
-                                stress: Math.max(0, Math.min(group.template.stressMax || 6, (instance.stress || 0) + stress)),
-                              })
-                            }
-                          }
-                        : undefined
-                    }
-                    onUpdate={
-                      group.type === 'adversary'
-                        ? updateAdversary
-                        : group.type === 'environment'
-                        ? updateEnvironment
-                        : updateCountdown
-                    }
-                    adversaries={adversaries}
-                    showAddRemoveButtons={browserOpenAtPosition !== null && group.type === 'adversary'}
-                    onEdit={group.type === 'adversary' ? (itemId) => handleEditAdversary(itemId) : undefined}
-                    onAddInstance={
-                      group.type === 'adversary'
-                        ? (item) => {
-                            const isMinion = item.type === 'Minion'
-                            const instancesToAdd = isMinion ? pcCount : 1
+      // Intersection of group with viewport, relative to the group wrapper
+      const visibleLeft = Math.max(groupStart, viewportLeft) - groupStart
+      const visibleRight = Math.min(groupEnd, viewportRight) - groupStart
+      const centerX = (visibleLeft + visibleRight) / 2
 
-                            if (isMinion && instancesToAdd > 1) {
-                              const instancesArray = Array(instancesToAdd)
-                                .fill(null)
-                                .map(() => ({ ...item }))
-                              createAdversariesBulk(instancesArray)
-                            } else {
-                              createAdversary(item)
-                            }
+      el.style.left = `${centerX}px`
+      // No CSS transition — immediate repositioning as user scrolls
+    })
+  }, [columnWidth, scrollContainerRef])
 
-                            setTimeout(() => {
-                              requestAnimationFrame(() => {
-                                requestAnimationFrame(() => {
-                                  if (!scrollContainerRef.current) return
-                                  const container = scrollContainerRef.current
-                                  const currentScroll = container.scrollLeft
-                                  const containerWidth = container.clientWidth
-                                  // When browser is open, the last column is covered — reduce visible area
-                                  const effectiveWidth = browserOpenAtPosition !== null
-                                    ? containerWidth - columnWidth - DASHBOARD_GAP
-                                    : containerWidth
+  // Attach scroll listener and run once on mount / when layout changes
+  useEffect(() => {
+    const container = scrollContainerRef.current
+    if (!container) return
+    updateLabelPositions()
+    container.addEventListener('scroll', updateLabelPositions, { passive: true })
+    return () => container.removeEventListener('scroll', updateLabelPositions)
+  }, [updateLabelPositions, entityGroups])
 
-                                  const updatedGroups = getEntityGroups()
-                                  const groupIndex = updatedGroups.findIndex(
-                                    (g) => g.baseName === group.baseName && g.type === 'adversary',
-                                  )
-                                  if (groupIndex >= 0) {
-                                    const cardPosition = DASHBOARD_GAP + groupIndex * (columnWidth + DASHBOARD_GAP)
-                                    const cardEnd = cardPosition + columnWidth
-                                    const margin = 10
-                                    const isVisible =
-                                      cardPosition >= currentScroll - margin &&
-                                      cardEnd <= currentScroll + effectiveWidth + margin
+  const registerLabel = (key, startFlatIndex, count) => (el) => {
+    if (el) {
+      labelInfoRef.current[key] = { el, startFlatIndex, count }
+    } else {
+      delete labelInfoRef.current[key]
+    }
+  }
 
-                                    if (!isVisible) {
-                                      let targetScroll
-                                      if (cardEnd > currentScroll + effectiveWidth + margin) {
-                                        // Card is hidden on the right (under browser) — use a snap-aligned target
-                                        const visibleColumns = Math.round((containerWidth - DASHBOARD_GAP) / (columnWidth + DASHBOARD_GAP))
-                                        targetScroll = (groupIndex - visibleColumns + 2) * (columnWidth + DASHBOARD_GAP)
-                                      } else {
-                                        // Card is hidden on the left — snap-aligned left edge
-                                        targetScroll = groupIndex * (columnWidth + DASHBOARD_GAP)
-                                      }
-                                      smoothScrollTo(Math.max(0, targetScroll), 500)
-                                    }
-                                  }
-                                })
-                              })
-                            }, 50)
-                          }
-                        : undefined
-                    }
-                    onRemoveInstance={
-                      group.type === 'adversary'
-                        ? () => {
-                            const isMinion = group.template?.type === 'Minion'
-                            const instancesToRemove = isMinion ? pcCount : 1
-                            const instances = [...group.instances].sort((a, b) => {
-                              const aNum = a.duplicateNumber || 1
-                              const bNum = b.duplicateNumber || 1
-                              return bNum - aNum
-                            })
-                            const instancesAfterRemoval = Math.max(0, instances.length - instancesToRemove)
-                            const isLastInstance = instancesAfterRemoval === 0
+  // Render a card Panel for a single entity group entry
+  const renderCardPanel = (group, flatIndex, cssClass, insideGroup = false) => {
+    const isSpacerPosition =
+      !isGrouped &&
+      removingCardSpacer &&
+      removingCardSpacer.baseName === group.baseName &&
+      group.type === 'adversary'
 
-                            if (instances.length === 0) {
-                              return
-                            }
-
-                            const instancesToDelete = instances.slice(0, instancesToRemove)
-
-                            if (isLastInstance) {
-                              const groupIndex = entityGroups.findIndex(
-                                (g) => g.baseName === group.baseName && g.type === 'adversary',
-                              )
-                              const isLeftmostColumn = groupIndex === 0
-                              let wasAtMaxScroll = false
-
-                              if (scrollContainerRef.current) {
-                                const container = scrollContainerRef.current
-                                const currentScroll = container.scrollLeft
-                                const maxScroll = container.scrollWidth - container.clientWidth
-                                wasAtMaxScroll = Math.abs(currentScroll - maxScroll) < 1
-                              }
-
-                              setRemovingCardSpacer({ baseName: group.baseName, groupIndex })
-                              setSpacerShrinking(false)
-
-                              if (isLeftmostColumn && scrollContainerRef.current) {
-                                scrollContainerRef.current.style.scrollSnapType = 'none'
-                              }
-
-                              requestAnimationFrame(() => {
-                                requestAnimationFrame(() => {
-                                  if (scrollContainerRef.current) {
-                                    scrollContainerRef.current.offsetHeight
-                                  }
-
-                                  instancesToDelete.forEach((instance) => {
-                                    deleteAdversary(instance.id)
-                                  })
-
-                                  requestAnimationFrame(() => {
-                                    requestAnimationFrame(() => {
-                                      if (scrollContainerRef.current) {
-                                        scrollContainerRef.current.offsetHeight
-                                      }
-
-                                      setTimeout(() => {
-                                        setSpacerShrinking(true)
-
-                                        if (wasAtMaxScroll && scrollContainerRef.current) {
-                                          const startTime = performance.now()
-                                          const duration = 300
-
-                                          const maintainScroll = () => {
-                                            if (!scrollContainerRef.current) return
-                                            const container = scrollContainerRef.current
-                                            const newMaxScroll = container.scrollWidth - container.clientWidth
-                                            container.scrollLeft = newMaxScroll
-
-                                            if (performance.now() - startTime < duration) {
-                                              requestAnimationFrame(maintainScroll)
-                                            }
-                                          }
-
-                                          requestAnimationFrame(maintainScroll)
-                                        }
-
-                                        setTimeout(() => {
-                                          setRemovingCardSpacer(null)
-                                          setSpacerShrinking(false)
-
-                                          if (isLeftmostColumn && scrollContainerRef.current) {
-                                            scrollContainerRef.current.style.scrollSnapType = 'x mandatory'
-                                          }
-
-                                          if (wasAtMaxScroll && scrollContainerRef.current) {
-                                            const container = scrollContainerRef.current
-                                            container.scrollLeft = container.scrollWidth - container.clientWidth
-                                          }
-                                        }, 300)
-                                      }, 50)
-                                    })
-                                  })
-                                })
-                              })
-                            } else {
-                              instancesToDelete.forEach((instance) => {
-                                deleteAdversary(instance.id)
-                              })
-                            }
-                          }
-                        : undefined
-                    }
-                  />
-                </Panel>,
-              )
-            })
-
-            if (removingCardSpacer && !items.some((item) => item?.key === `spacer-${removingCardSpacer.baseName}`)) {
-              const insertIndex = Math.min(removingCardSpacer.groupIndex, items.length)
-              items.splice(
-                insertIndex,
-                0,
-                <Panel
-                  key={`spacer-${removingCardSpacer.baseName}`}
-                  className="dashboard-column"
-                  style={{
-                    width: spacerShrinking ? '0px' : `${columnWidth}px`,
-                    flexShrink: 0,
-                    flexGrow: 0,
-                    flex: 'none',
-                    paddingRight: '0',
-                    paddingTop: spacerShrinking ? '0px' : `${DASHBOARD_GAP}px`,
-                    paddingBottom: spacerShrinking ? '0px' : `${DASHBOARD_GAP}px`,
-                    scrollSnapAlign: 'none',
-                    overflow: 'hidden',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'stretch',
-                    height: '100%',
-                    opacity: 0,
-                    transition: 'width 0.3s ease, padding-top 0.3s ease, padding-bottom 0.3s ease',
-                  }}
-                />,
-              )
-            }
-
-            return items
-          })()}
-      {browserOpenAtPosition !== null && (
-        <div
+    if (isSpacerPosition) {
+      return (
+        <Panel
+          key={`spacer-${removingCardSpacer.baseName}`}
           style={{
-            width: `${columnWidth}px`,
+            width: spacerShrinking ? '0px' : `${columnWidth}px`,
+            flexShrink: 0, flexGrow: 0, flex: 'none',
+            paddingRight: '0',
+            paddingTop: spacerShrinking ? '0px' : `${DASHBOARD_GAP}px`,
+            paddingBottom: spacerShrinking ? '0px' : `${DASHBOARD_GAP}px`,
+            scrollSnapAlign: 'none',
+            overflow: 'hidden',
+            display: 'flex', flexDirection: 'column', alignItems: 'stretch',
+            height: '100%', opacity: 0,
+            transition: 'width 0.3s ease, padding-top 0.3s ease, padding-bottom 0.3s ease',
+          }}
+        />
+      )
+    }
+
+    const isEditing = group.type === 'adversary' && editingAdversaryId && group.instances.some(i => i.id === editingAdversaryId)
+
+    return (
+      <Panel
+        key={group.type === 'adversary' ? `adversary-${group.template?.id || group.baseName}` : `${group.type}-${group.baseName}`}
+        className={cssClass}
+        style={{
+          width: `${columnWidth}px`,
+          flexShrink: 0, flexGrow: 0, flex: 'none',
+          paddingRight: '0',
+          // Cards inside a group wrapper get no top padding — the label area provides it
+          paddingTop: insideGroup ? '0' : `${DASHBOARD_GAP}px`,
+          paddingBottom: `${DASHBOARD_GAP}px`,
+          scrollSnapAlign: 'start',
+          overflow: group.type === 'adversary' ? 'visible' : 'hidden',
+          display: 'flex', flexDirection: 'column', alignItems: 'stretch',
+          height: 'auto',
+          opacity: newCards.has(`${group.type}-${group.baseName}`) ? 0 : 1,
+          transition: 'opacity 0.2s ease',
+        }}
+      >
+        <GameCard
+          type={group.type}
+          item={
+            group.type === 'adversary'
+              ? { ...group.template, name: group.baseName, hp: 0, stress: 0, isDead: false }
+              : { ...group.instances[0], name: group.instances[0]?.name || group.baseName }
+          }
+          mode="expanded"
+          instances={
+            group.type === 'adversary'
+              ? [...group.instances]
+                  .sort((a, b) => (a.duplicateNumber || 1) - (b.duplicateNumber || 1))
+                  .map(inst => ({ ...inst, hpMax: group.template.hpMax, stressMax: group.template.stressMax }))
+              : group.instances
+          }
+          showCustomCreator={isEditing}
+          onSaveCustomAdversary={isEditing ? handleSaveCustomAdversary : undefined}
+          onCancelEdit={isEditing ? handleCancelEdit : undefined}
+          isStockAdversary={isEditing ? (!group.template?.source || group.template?.source !== 'Homebrew') : false}
+          onApplyDamage={
+            group.type === 'adversary'
+              ? (id, damage) => {
+                  const instance = group.instances.find(i => i.id === id)
+                  if (instance) updateAdversary(id, { hp: Math.min(group.template.hpMax || 1, (instance.hp || 0) + damage) })
+                }
+              : undefined
+          }
+          onApplyHealing={
+            group.type === 'adversary'
+              ? (id, healing) => {
+                  const instance = group.instances.find(i => i.id === id)
+                  if (instance) updateAdversary(id, { hp: Math.max(0, (instance.hp || 0) - healing) })
+                }
+              : undefined
+          }
+          onApplyStressChange={
+            group.type === 'adversary'
+              ? (id, stress) => {
+                  const instance = group.instances.find(i => i.id === id)
+                  if (instance) updateAdversary(id, {
+                    stress: Math.max(0, Math.min(group.template.stressMax || 6, (instance.stress || 0) + stress)),
+                  })
+                }
+              : undefined
+          }
+          onUpdate={
+            group.type === 'adversary' ? updateAdversary
+              : group.type === 'environment' ? updateEnvironment
+              : updateCountdown
+          }
+          adversaries={adversaries}
+          showAddRemoveButtons={browserOpenAtPosition !== null && group.type === 'adversary'}
+          onEdit={group.type === 'adversary' ? itemId => handleEditAdversary(itemId) : undefined}
+          onAddInstance={
+            group.type === 'adversary'
+              ? item => {
+                  const isMinion = item.type === 'Minion'
+                  const instancesToAdd = isMinion ? pcCount : 1
+                  if (isMinion && instancesToAdd > 1) {
+                    createAdversariesBulk(Array(instancesToAdd).fill(null).map(() => ({ ...item })))
+                  } else {
+                    createAdversary(item)
+                  }
+                  setTimeout(() => {
+                    requestAnimationFrame(() => requestAnimationFrame(() => {
+                      if (!scrollContainerRef.current) return
+                      const container = scrollContainerRef.current
+                      const currentScroll = container.scrollLeft
+                      const containerWidth = container.clientWidth
+                      const effectiveWidth = browserOpenAtPosition !== null
+                        ? containerWidth - columnWidth - DASHBOARD_GAP
+                        : containerWidth
+                      const updatedGroups = getEntityGroups()
+                      const groupIndex = updatedGroups.findIndex(g => g.baseName === group.baseName && g.type === 'adversary')
+                      if (groupIndex >= 0) {
+                        const cardPosition = DASHBOARD_GAP + groupIndex * (columnWidth + DASHBOARD_GAP)
+                        const cardEnd = cardPosition + columnWidth
+                        const margin = 10
+                        const isVisible = cardPosition >= currentScroll - margin && cardEnd <= currentScroll + effectiveWidth + margin
+                        if (!isVisible) {
+                          let targetScroll
+                          if (cardEnd > currentScroll + effectiveWidth + margin) {
+                            const visibleColumns = Math.round((containerWidth - DASHBOARD_GAP) / (columnWidth + DASHBOARD_GAP))
+                            targetScroll = (groupIndex - visibleColumns + 2) * (columnWidth + DASHBOARD_GAP)
+                          } else {
+                            targetScroll = groupIndex * (columnWidth + DASHBOARD_GAP)
+                          }
+                          smoothScrollTo(Math.max(0, targetScroll), 500)
+                        }
+                      }
+                    }))
+                  }, 50)
+                }
+              : undefined
+          }
+          onRemoveInstance={
+            group.type === 'adversary'
+              ? () => {
+                  const isMinion = group.template?.type === 'Minion'
+                  const instancesToRemove = isMinion ? pcCount : 1
+                  const instances = [...group.instances].sort((a, b) => (b.duplicateNumber || 1) - (a.duplicateNumber || 1))
+                  if (instances.length === 0) return
+                  const isLastInstance = Math.max(0, instances.length - instancesToRemove) === 0
+                  const instancesToDelete = instances.slice(0, instancesToRemove)
+
+                  if (isLastInstance && !isGrouped) {
+                    const groupIndex = entityGroups.findIndex(g => g.baseName === group.baseName && g.type === 'adversary')
+                    const isLeftmostColumn = groupIndex === 0
+                    let wasAtMaxScroll = false
+                    if (scrollContainerRef.current) {
+                      const c = scrollContainerRef.current
+                      wasAtMaxScroll = Math.abs(c.scrollLeft - (c.scrollWidth - c.clientWidth)) < 1
+                    }
+                    setRemovingCardSpacer({ baseName: group.baseName, groupIndex })
+                    setSpacerShrinking(false)
+                    if (isLeftmostColumn && scrollContainerRef.current) scrollContainerRef.current.style.scrollSnapType = 'none'
+                    requestAnimationFrame(() => requestAnimationFrame(() => {
+                      if (scrollContainerRef.current) scrollContainerRef.current.offsetHeight
+                      instancesToDelete.forEach(inst => deleteAdversary(inst.id))
+                      requestAnimationFrame(() => requestAnimationFrame(() => {
+                        if (scrollContainerRef.current) scrollContainerRef.current.offsetHeight
+                        setTimeout(() => {
+                          setSpacerShrinking(true)
+                          if (wasAtMaxScroll && scrollContainerRef.current) {
+                            const startTime = performance.now()
+                            const duration = 300
+                            const maintainScroll = () => {
+                              if (!scrollContainerRef.current) return
+                              scrollContainerRef.current.scrollLeft = scrollContainerRef.current.scrollWidth - scrollContainerRef.current.clientWidth
+                              if (performance.now() - startTime < duration) requestAnimationFrame(maintainScroll)
+                            }
+                            requestAnimationFrame(maintainScroll)
+                          }
+                          setTimeout(() => {
+                            setRemovingCardSpacer(null)
+                            setSpacerShrinking(false)
+                            if (isLeftmostColumn && scrollContainerRef.current) scrollContainerRef.current.style.scrollSnapType = 'x mandatory'
+                            if (wasAtMaxScroll && scrollContainerRef.current) {
+                              scrollContainerRef.current.scrollLeft = scrollContainerRef.current.scrollWidth - scrollContainerRef.current.clientWidth
+                            }
+                          }, 300)
+                        }, 50)
+                      }))
+                    }))
+                  } else {
+                    instancesToDelete.forEach(inst => deleteAdversary(inst.id))
+                  }
+                }
+              : undefined
+          }
+        />
+      </Panel>
+    )
+  }
+
+  const sections = buildSections(entityGroups)
+  const items = []
+
+  sections.forEach((section, sectionIndex) => {
+    const isFirstSection = sectionIndex === 0
+    const isLastSection = sectionIndex === sections.length - 1
+
+    if (section.type === 'grouped') {
+      const { groupName, entries, startFlatIndex } = section
+      const sectionKey = `group-section-${groupName}-${startFlatIndex}`
+      const count = entries.length
+
+      const cards = entries.map((group, i) => {
+        const isFirst = isFirstSection && i === 0
+        const isLast = isLastSection && i === entries.length - 1
+        const cssClass = isFirst ? 'dashboard-column dashboard-column--first'
+          : isLast ? 'dashboard-column dashboard-column--last'
+          : 'dashboard-column'
+        return renderCardPanel(group, startFlatIndex + i, cssClass, true)
+      })
+
+      items.push(
+        <div
+          key={sectionKey}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
             flexShrink: 0,
             flexGrow: 0,
             flex: 'none',
-            height: '100%',
           }}
-        />
+        >
+          {/* Label area: line + centered label. Label position set by scroll handler. */}
+          <div style={{ position: 'relative', height: DASHBOARD_GAP + 20, flexShrink: 0 }}>
+            {/* Horizontal dividing line spanning full group width */}
+            <div style={{
+              position: 'absolute',
+              left: 0, right: 0,
+              top: '50%',
+              height: 1,
+              backgroundColor: 'var(--border)',
+              pointerEvents: 'none',
+            }} />
+            {/* Label text: positioned by JS, centered over visible portion */}
+            <span
+              ref={registerLabel(sectionKey, startFlatIndex, count)}
+              style={{
+                position: 'absolute',
+                top: '50%',
+                transform: 'translate(-50%, -50%)',
+                backgroundColor: 'var(--bg-primary)',
+                padding: '0 8px',
+                fontSize: '0.62rem',
+                fontWeight: 700,
+                letterSpacing: '0.1em',
+                textTransform: 'uppercase',
+                color: 'var(--text-secondary)',
+                whiteSpace: 'nowrap',
+                pointerEvents: 'none',
+                userSelect: 'none',
+              }}
+            >
+              {groupName}
+            </span>
+          </div>
+
+          {/* Cards row */}
+          <div style={{ display: 'flex', flexDirection: 'row', gap: `${DASHBOARD_GAP}px`, alignItems: 'stretch' }}>
+            {cards}
+          </div>
+        </div>
+      )
+    } else {
+      const { entry: group, flatIndex } = section
+      const cssClass = isFirstSection ? 'dashboard-column dashboard-column--first'
+        : isLastSection ? 'dashboard-column dashboard-column--last'
+        : 'dashboard-column'
+      items.push(renderCardPanel(group, flatIndex, cssClass, false))
+    }
+  })
+
+  // Spacer for animated card removal (non-grouped mode only)
+  if (!isGrouped && removingCardSpacer && !items.some(item => item?.key === `spacer-${removingCardSpacer.baseName}`)) {
+    const insertIndex = Math.min(removingCardSpacer.groupIndex, items.length)
+    items.splice(insertIndex, 0,
+      <Panel
+        key={`spacer-${removingCardSpacer.baseName}`}
+        className="dashboard-column"
+        style={{
+          width: spacerShrinking ? '0px' : `${columnWidth}px`,
+          flexShrink: 0, flexGrow: 0, flex: 'none',
+          paddingRight: '0',
+          paddingTop: spacerShrinking ? '0px' : `${DASHBOARD_GAP}px`,
+          paddingBottom: spacerShrinking ? '0px' : `${DASHBOARD_GAP}px`,
+          scrollSnapAlign: 'none',
+          overflow: 'hidden',
+          display: 'flex', flexDirection: 'column', alignItems: 'stretch',
+          height: '100%', opacity: 0,
+          transition: 'width 0.3s ease, padding-top 0.3s ease, padding-bottom 0.3s ease',
+        }}
+      />
+    )
+  }
+
+  return (
+    <div ref={scrollContainerRef} className="dashboard-scroll-container" onScroll={onScroll}>
+      {items.length > 0 ? items : null}
+      {browserOpenAtPosition !== null && (
+        <div style={{ width: `${columnWidth}px`, flexShrink: 0, flexGrow: 0, flex: 'none', height: '100%' }} />
       )}
     </div>
   )
 }
 
 export default EntityColumns
-

--- a/src/components/Dashboard/EntityColumns.jsx
+++ b/src/components/Dashboard/EntityColumns.jsx
@@ -38,46 +38,6 @@ const EntityColumns = ({
             const items = []
 
             entityGroups.forEach((group, index) => {
-              if (group.type === 'separator') {
-                items.push(
-                  <div
-                    key={group.baseName}
-                    style={{
-                      flexShrink: 0,
-                      flexGrow: 0,
-                      flex: 'none',
-                      width: '2px',
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'center',
-                      justifyContent: 'flex-start',
-                      paddingTop: `${DASHBOARD_GAP + 8}px`,
-                      scrollSnapAlign: 'none',
-                    }}
-                  >
-                    <div style={{
-                      writingMode: 'vertical-rl',
-                      textOrientation: 'mixed',
-                      transform: 'rotate(180deg)',
-                      fontSize: '0.65rem',
-                      fontWeight: 700,
-                      letterSpacing: '0.1em',
-                      textTransform: 'uppercase',
-                      color: 'var(--text-secondary)',
-                      backgroundColor: 'var(--bg-primary)',
-                      padding: '6px 3px',
-                      borderRadius: '4px',
-                      whiteSpace: 'nowrap',
-                      userSelect: 'none',
-                    }}>
-                      {group.label}
-                    </div>
-                    <div style={{ flex: 1, width: 1, backgroundColor: 'var(--border)', marginTop: 4 }} />
-                  </div>
-                )
-                return
-              }
-
               const isSpacerPosition =
                 removingCardSpacer && removingCardSpacer.baseName === group.baseName && group.type === 'adversary'
 
@@ -135,6 +95,19 @@ const EntityColumns = ({
                     transition: 'opacity 0.2s ease',
                   }}
                 >
+                  {group.groupLabel && (
+                    <div style={{
+                      fontSize: '0.65rem',
+                      fontWeight: 700,
+                      letterSpacing: '0.1em',
+                      textTransform: 'uppercase',
+                      color: 'var(--text-secondary)',
+                      padding: '0 2px 6px',
+                      userSelect: 'none',
+                    }}>
+                      {group.groupLabel}
+                    </div>
+                  )}
                   <GameCard
                     type={group.type}
                     item={

--- a/src/components/Dashboard/EntityColumns.jsx
+++ b/src/components/Dashboard/EntityColumns.jsx
@@ -3,28 +3,75 @@ import Panel from './Panels'
 import GameCard from '../Adversaries/GameCard'
 import { DASHBOARD_GAP } from './constants'
 
-// Collect consecutive adversary entries with the same groupName into sections.
-function buildSections(entityGroups) {
-  const sections = []
-  let i = 0
-  while (i < entityGroups.length) {
-    const g = entityGroups[i]
-    if (g.groupName && g.type === 'adversary') {
-      const entries = [g]
-      let j = i + 1
-      while (j < entityGroups.length && entityGroups[j].groupName === g.groupName && entityGroups[j].type === 'adversary') {
-        entries.push(entityGroups[j])
-        j++
-      }
-      sections.push({ type: 'grouped', groupName: g.groupName, entries, startFlatIndex: i })
-      i = j
-    } else {
-      sections.push({ type: 'solo', entry: g, flatIndex: i })
-      i++
-    }
+// Width of each vertical group divider column (narrow but enough for rotated text)
+const DIVIDER_WIDTH = 20
+
+// Count how many group-boundary dividers appear strictly before flat index `i`
+// (a boundary is where groupName changes from one value to another non-null value)
+function numDividersBefore(flatIndex, groups) {
+  if (flatIndex === 0) return 0
+  let count = 0
+  let lastGN = groups[0]?.groupName ?? null
+  for (let i = 1; i < flatIndex; i++) {
+    const gn = groups[i]?.groupName ?? null
+    if (gn && gn !== lastGN) count++
+    lastGN = gn || lastGN  // keep last non-null groupName when transitioning
   }
-  return sections
+  return count
 }
+
+// Pixel scroll-left of a card at flat index `i`, accounting for any dividers before it
+function cardScrollPosition(flatIndex, groups, columnWidth) {
+  const divs = numDividersBefore(flatIndex, groups)
+  return DASHBOARD_GAP + flatIndex * (columnWidth + DASHBOARD_GAP) + divs * (DIVIDER_WIDTH + DASHBOARD_GAP)
+}
+
+const VerticalDivider = ({ groupName }) => (
+  <div style={{
+    width: DIVIDER_WIDTH,
+    flexShrink: 0,
+    flexGrow: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    paddingTop: DASHBOARD_GAP,
+    paddingBottom: DASHBOARD_GAP,
+    scrollSnapAlign: 'none',
+    position: 'relative',
+  }}>
+    {/* Thin vertical line */}
+    <div style={{
+      position: 'absolute',
+      top: DASHBOARD_GAP,
+      bottom: DASHBOARD_GAP,
+      left: '50%',
+      width: 1,
+      backgroundColor: 'var(--border)',
+      transform: 'translateX(-50%)',
+    }} />
+    {/* Rotated group label, centered on the line */}
+    <div style={{
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%) rotate(180deg)',
+      writingMode: 'vertical-rl',
+      textOrientation: 'mixed',
+      fontSize: '0.68rem',
+      fontWeight: 700,
+      letterSpacing: '0.1em',
+      textTransform: 'uppercase',
+      color: 'var(--text-primary)',
+      backgroundColor: 'var(--bg-primary)',
+      padding: '8px 2px',
+      whiteSpace: 'nowrap',
+      userSelect: 'none',
+      pointerEvents: 'none',
+    }}>
+      {groupName}
+    </div>
+  </div>
+)
 
 const EntityColumns = ({
   entityGroups,
@@ -54,56 +101,8 @@ const EntityColumns = ({
   onOpenBrowser,
 }) => {
   const isGrouped = entityGroups.some(g => g.groupName)
-  // Map of sectionKey → { el (label DOM node), startFlatIndex, count }
-  const labelInfoRef = useRef({})
 
-  // Reposition all group labels so each is centered over its visible cards.
-  // Called on scroll and whenever layout changes (columns, entityGroups).
-  const updateLabelPositions = useCallback(() => {
-    const container = scrollContainerRef.current
-    if (!container) return
-    const viewportLeft = container.scrollLeft
-    const viewportRight = viewportLeft + container.clientWidth
-
-    Object.values(labelInfoRef.current).forEach(({ el, startFlatIndex, count }) => {
-      if (!el) return
-      const groupStart = DASHBOARD_GAP + startFlatIndex * (columnWidth + DASHBOARD_GAP)
-      const groupWidth = count * columnWidth + (count - 1) * DASHBOARD_GAP
-      const groupEnd = groupStart + groupWidth
-
-      // Intersection of group with viewport, relative to the group wrapper
-      const visibleLeft = Math.max(groupStart, viewportLeft) - groupStart
-      const visibleRight = Math.min(groupEnd, viewportRight) - groupStart
-      const centerX = (visibleLeft + visibleRight) / 2
-
-      // Clamp so the label never bleeds outside the group wrapper
-      const halfLabel = el.offsetWidth / 2
-      const clamped = Math.max(halfLabel, Math.min(groupWidth - halfLabel, centerX))
-
-      el.style.left = `${clamped}px`
-      // No CSS transition — immediate repositioning as user scrolls
-    })
-  }, [columnWidth, scrollContainerRef])
-
-  // Attach scroll listener and run once on mount / when layout changes
-  useEffect(() => {
-    const container = scrollContainerRef.current
-    if (!container) return
-    updateLabelPositions()
-    container.addEventListener('scroll', updateLabelPositions, { passive: true })
-    return () => container.removeEventListener('scroll', updateLabelPositions)
-  }, [updateLabelPositions, entityGroups])
-
-  const registerLabel = (key, startFlatIndex, count) => (el) => {
-    if (el) {
-      labelInfoRef.current[key] = { el, startFlatIndex, count }
-    } else {
-      delete labelInfoRef.current[key]
-    }
-  }
-
-  // Render a card Panel for a single entity group entry
-  const renderCardPanel = (group, flatIndex, cssClass, insideGroup = false) => {
+  const renderCardPanel = (group, flatIndex, cssClass, currentDivCount) => {
     const isSpacerPosition =
       !isGrouped &&
       removingCardSpacer &&
@@ -140,8 +139,7 @@ const EntityColumns = ({
           width: `${columnWidth}px`,
           flexShrink: 0, flexGrow: 0, flex: 'none',
           paddingRight: '0',
-          // Cards inside a group wrapper get no top padding — the label area provides it
-          paddingTop: insideGroup ? '0' : `${DASHBOARD_GAP}px`,
+          paddingTop: `${DASHBOARD_GAP}px`,
           paddingBottom: `${DASHBOARD_GAP}px`,
           scrollSnapAlign: 'start',
           overflow: group.type === 'adversary' ? 'visible' : 'hidden',
@@ -226,7 +224,8 @@ const EntityColumns = ({
                       const updatedGroups = getEntityGroups()
                       const groupIndex = updatedGroups.findIndex(g => g.baseName === group.baseName && g.type === 'adversary')
                       if (groupIndex >= 0) {
-                        const cardPosition = DASHBOARD_GAP + groupIndex * (columnWidth + DASHBOARD_GAP)
+                        // Use divider-aware position formula
+                        const cardPosition = cardScrollPosition(groupIndex, updatedGroups, columnWidth)
                         const cardEnd = cardPosition + columnWidth
                         const margin = 10
                         const isVisible = cardPosition >= currentScroll - margin && cardEnd <= currentScroll + effectiveWidth + margin
@@ -234,9 +233,9 @@ const EntityColumns = ({
                           let targetScroll
                           if (cardEnd > currentScroll + effectiveWidth + margin) {
                             const visibleColumns = Math.round((containerWidth - DASHBOARD_GAP) / (columnWidth + DASHBOARD_GAP))
-                            targetScroll = (groupIndex - visibleColumns + 2) * (columnWidth + DASHBOARD_GAP)
+                            targetScroll = cardScrollPosition(Math.max(0, groupIndex - visibleColumns + 2), updatedGroups, columnWidth)
                           } else {
-                            targetScroll = groupIndex * (columnWidth + DASHBOARD_GAP)
+                            targetScroll = cardScrollPosition(groupIndex, updatedGroups, columnWidth) - DASHBOARD_GAP
                           }
                           smoothScrollTo(Math.max(0, targetScroll), 500)
                         }
@@ -264,7 +263,9 @@ const EntityColumns = ({
                       const c = scrollContainerRef.current
                       wasAtMaxScroll = Math.abs(c.scrollLeft - (c.scrollWidth - c.clientWidth)) < 1
                     }
-                    setRemovingCardSpacer({ baseName: group.baseName, groupIndex })
+                    // items-array index = flat index + number of dividers before it
+                    const itemsIndex = groupIndex + numDividersBefore(groupIndex, entityGroups)
+                    setRemovingCardSpacer({ baseName: group.baseName, groupIndex: itemsIndex })
                     setSpacerShrinking(false)
                     if (isLeftmostColumn && scrollContainerRef.current) scrollContainerRef.current.style.scrollSnapType = 'none'
                     requestAnimationFrame(() => requestAnimationFrame(() => {
@@ -306,106 +307,33 @@ const EntityColumns = ({
     )
   }
 
-  const sections = buildSections(entityGroups)
+  // Build the flat items array, injecting vertical dividers between groups
   const items = []
+  let lastGroupName = null
+  let divCount = 0
 
-  sections.forEach((section, sectionIndex) => {
-    const isFirstSection = sectionIndex === 0
-    const isLastSection = sectionIndex === sections.length - 1
+  entityGroups.forEach((group, index) => {
+    const isFirst = index === 0
+    const isLast = index === entityGroups.length - 1
+    const cssClass = isFirst ? 'dashboard-column dashboard-column--first'
+      : isLast ? 'dashboard-column dashboard-column--last'
+      : 'dashboard-column'
 
-    if (section.type === 'grouped') {
-      const { groupName, entries, startFlatIndex } = section
-      const sectionKey = `group-section-${groupName}-${startFlatIndex}`
-      const count = entries.length
-
-      const cards = entries.map((group, i) => {
-        const isFirst = isFirstSection && i === 0
-        const isLast = isLastSection && i === entries.length - 1
-        const cssClass = isFirst ? 'dashboard-column dashboard-column--first'
-          : isLast ? 'dashboard-column dashboard-column--last'
-          : 'dashboard-column'
-        return renderCardPanel(group, startFlatIndex + i, cssClass, true)
-      })
-
-      items.push(
-        <div
-          key={sectionKey}
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            flexShrink: 0,
-            flexGrow: 0,
-            flex: 'none',
-          }}
-        >
-          {/* Label area: bracket line + centered label. Label position set by scroll handler. */}
-          <div style={{ position: 'relative', height: DASHBOARD_GAP + 24, flexShrink: 0 }}>
-            {/* Horizontal line spanning full group width */}
-            <div style={{
-              position: 'absolute',
-              left: 0, right: 0,
-              top: '50%',
-              height: 1,
-              backgroundColor: 'var(--border)',
-              pointerEvents: 'none',
-            }} />
-            {/* Left bracket cap */}
-            <div style={{
-              position: 'absolute',
-              left: 0, top: '50%',
-              transform: 'translateY(-50%)',
-              width: 1, height: 12,
-              backgroundColor: 'var(--border)',
-              pointerEvents: 'none',
-            }} />
-            {/* Right bracket cap */}
-            <div style={{
-              position: 'absolute',
-              right: 0, top: '50%',
-              transform: 'translateY(-50%)',
-              width: 1, height: 12,
-              backgroundColor: 'var(--border)',
-              pointerEvents: 'none',
-            }} />
-            {/* Label text: positioned by JS, centered over visible portion */}
-            <span
-              ref={registerLabel(sectionKey, startFlatIndex, count)}
-              style={{
-                position: 'absolute',
-                top: '50%',
-                transform: 'translate(-50%, -50%)',
-                backgroundColor: 'var(--bg-primary)',
-                padding: '0 8px',
-                fontSize: '0.72rem',
-                fontWeight: 700,
-                letterSpacing: '0.1em',
-                textTransform: 'uppercase',
-                color: 'var(--text-primary)',
-                whiteSpace: 'nowrap',
-                pointerEvents: 'none',
-                userSelect: 'none',
-              }}
-            >
-              {groupName}
-            </span>
-          </div>
-
-          {/* Cards row */}
-          <div style={{ display: 'flex', flexDirection: 'row', gap: `${DASHBOARD_GAP}px`, alignItems: 'stretch' }}>
-            {cards}
-          </div>
-        </div>
-      )
-    } else {
-      const { entry: group, flatIndex } = section
-      const cssClass = isFirstSection ? 'dashboard-column dashboard-column--first'
-        : isLastSection ? 'dashboard-column dashboard-column--last'
-        : 'dashboard-column'
-      items.push(renderCardPanel(group, flatIndex, cssClass, false))
+    // Inject a divider before each new group boundary (not before the very first group)
+    if (group.groupName && group.groupName !== lastGroupName) {
+      if (lastGroupName !== null) {
+        items.push(<VerticalDivider key={`divider-${group.groupName}-${index}`} groupName={group.groupName} />)
+        divCount++
+      }
+      lastGroupName = group.groupName
+    } else if (!group.groupName) {
+      lastGroupName = null
     }
+
+    items.push(renderCardPanel(group, index, cssClass, divCount))
   })
 
-  // Spacer for animated card removal (non-grouped mode only)
+  // Spacer for animated card removal (only when groupBy is off so no dividers exist)
   if (!isGrouped && removingCardSpacer && !items.some(item => item?.key === `spacer-${removingCardSpacer.baseName}`)) {
     const insertIndex = Math.min(removingCardSpacer.groupIndex, items.length)
     items.splice(insertIndex, 0,

--- a/src/components/Dashboard/EntityColumns.jsx
+++ b/src/components/Dashboard/EntityColumns.jsx
@@ -76,7 +76,11 @@ const EntityColumns = ({
       const visibleRight = Math.min(groupEnd, viewportRight) - groupStart
       const centerX = (visibleLeft + visibleRight) / 2
 
-      el.style.left = `${centerX}px`
+      // Clamp so the label never bleeds outside the group wrapper
+      const halfLabel = el.offsetWidth / 2
+      const clamped = Math.max(halfLabel, Math.min(groupWidth - halfLabel, centerX))
+
+      el.style.left = `${clamped}px`
       // No CSS transition — immediate repositioning as user scrolls
     })
   }, [columnWidth, scrollContainerRef])
@@ -334,14 +338,32 @@ const EntityColumns = ({
             flex: 'none',
           }}
         >
-          {/* Label area: line + centered label. Label position set by scroll handler. */}
-          <div style={{ position: 'relative', height: DASHBOARD_GAP + 20, flexShrink: 0 }}>
-            {/* Horizontal dividing line spanning full group width */}
+          {/* Label area: bracket line + centered label. Label position set by scroll handler. */}
+          <div style={{ position: 'relative', height: DASHBOARD_GAP + 24, flexShrink: 0 }}>
+            {/* Horizontal line spanning full group width */}
             <div style={{
               position: 'absolute',
               left: 0, right: 0,
               top: '50%',
               height: 1,
+              backgroundColor: 'var(--border)',
+              pointerEvents: 'none',
+            }} />
+            {/* Left bracket cap */}
+            <div style={{
+              position: 'absolute',
+              left: 0, top: '50%',
+              transform: 'translateY(-50%)',
+              width: 1, height: 12,
+              backgroundColor: 'var(--border)',
+              pointerEvents: 'none',
+            }} />
+            {/* Right bracket cap */}
+            <div style={{
+              position: 'absolute',
+              right: 0, top: '50%',
+              transform: 'translateY(-50%)',
+              width: 1, height: 12,
               backgroundColor: 'var(--border)',
               pointerEvents: 'none',
             }} />
@@ -354,11 +376,11 @@ const EntityColumns = ({
                 transform: 'translate(-50%, -50%)',
                 backgroundColor: 'var(--bg-primary)',
                 padding: '0 8px',
-                fontSize: '0.62rem',
+                fontSize: '0.72rem',
                 fontWeight: 700,
                 letterSpacing: '0.1em',
                 textTransform: 'uppercase',
-                color: 'var(--text-secondary)',
+                color: 'var(--text-primary)',
                 whiteSpace: 'nowrap',
                 pointerEvents: 'none',
                 userSelect: 'none',

--- a/src/components/Dashboard/EntityColumns.jsx
+++ b/src/components/Dashboard/EntityColumns.jsx
@@ -1,77 +1,30 @@
-import React, { useEffect, useRef, useCallback } from 'react'
+import React from 'react'
 import Panel from './Panels'
 import GameCard from '../Adversaries/GameCard'
 import { DASHBOARD_GAP } from './constants'
 
-// Width of each vertical group divider column (narrow but enough for rotated text)
-const DIVIDER_WIDTH = 20
-
-// Count how many group-boundary dividers appear strictly before flat index `i`
-// (a boundary is where groupName changes from one value to another non-null value)
-function numDividersBefore(flatIndex, groups) {
-  if (flatIndex === 0) return 0
-  let count = 0
-  let lastGN = groups[0]?.groupName ?? null
-  for (let i = 1; i < flatIndex; i++) {
-    const gn = groups[i]?.groupName ?? null
-    if (gn && gn !== lastGN) count++
-    lastGN = gn || lastGN  // keep last non-null groupName when transitioning
+// Collect consecutive adversary entries with the same groupName into sections.
+function buildSections(entityGroups) {
+  const sections = []
+  let i = 0
+  while (i < entityGroups.length) {
+    const g = entityGroups[i]
+    if (g.groupName && g.type === 'adversary') {
+      const entries = [g]
+      let j = i + 1
+      while (j < entityGroups.length && entityGroups[j].groupName === g.groupName && entityGroups[j].type === 'adversary') {
+        entries.push(entityGroups[j])
+        j++
+      }
+      sections.push({ type: 'grouped', groupName: g.groupName, entries, startFlatIndex: i })
+      i = j
+    } else {
+      sections.push({ type: 'solo', entry: g, flatIndex: i })
+      i++
+    }
   }
-  return count
+  return sections
 }
-
-// Pixel scroll-left of a card at flat index `i`, accounting for any dividers before it
-function cardScrollPosition(flatIndex, groups, columnWidth) {
-  const divs = numDividersBefore(flatIndex, groups)
-  return DASHBOARD_GAP + flatIndex * (columnWidth + DASHBOARD_GAP) + divs * (DIVIDER_WIDTH + DASHBOARD_GAP)
-}
-
-const VerticalDivider = ({ groupName }) => (
-  <div style={{
-    width: DIVIDER_WIDTH,
-    flexShrink: 0,
-    flexGrow: 0,
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    paddingTop: DASHBOARD_GAP,
-    paddingBottom: DASHBOARD_GAP,
-    scrollSnapAlign: 'none',
-    position: 'relative',
-  }}>
-    {/* Thin vertical line */}
-    <div style={{
-      position: 'absolute',
-      top: DASHBOARD_GAP,
-      bottom: DASHBOARD_GAP,
-      left: '50%',
-      width: 1,
-      backgroundColor: 'var(--border)',
-      transform: 'translateX(-50%)',
-    }} />
-    {/* Rotated group label, centered on the line */}
-    <div style={{
-      position: 'absolute',
-      top: '50%',
-      left: '50%',
-      transform: 'translate(-50%, -50%) rotate(180deg)',
-      writingMode: 'vertical-rl',
-      textOrientation: 'mixed',
-      fontSize: '0.68rem',
-      fontWeight: 700,
-      letterSpacing: '0.1em',
-      textTransform: 'uppercase',
-      color: 'var(--text-primary)',
-      backgroundColor: 'var(--bg-primary)',
-      padding: '8px 2px',
-      whiteSpace: 'nowrap',
-      userSelect: 'none',
-      pointerEvents: 'none',
-    }}>
-      {groupName}
-    </div>
-  </div>
-)
 
 const EntityColumns = ({
   entityGroups,
@@ -102,7 +55,8 @@ const EntityColumns = ({
 }) => {
   const isGrouped = entityGroups.some(g => g.groupName)
 
-  const renderCardPanel = (group, flatIndex, cssClass, currentDivCount) => {
+  // Render a single adversary/countdown card Panel
+  const renderCardPanel = (group, flatIndex, cssClass, insideGroup = false) => {
     const isSpacerPosition =
       !isGrouped &&
       removingCardSpacer &&
@@ -129,17 +83,21 @@ const EntityColumns = ({
       )
     }
 
-    const isEditing = group.type === 'adversary' && editingAdversaryId && group.instances.some(i => i.id === editingAdversaryId)
+    const isEditing = group.type === 'adversary' && editingAdversaryId &&
+      group.instances.some(i => i.id === editingAdversaryId)
 
     return (
       <Panel
-        key={group.type === 'adversary' ? `adversary-${group.template?.id || group.baseName}` : `${group.type}-${group.baseName}`}
+        key={group.type === 'adversary'
+          ? `adversary-${group.template?.id || group.baseName}`
+          : `${group.type}-${group.baseName}`}
         className={cssClass}
         style={{
           width: `${columnWidth}px`,
           flexShrink: 0, flexGrow: 0, flex: 'none',
           paddingRight: '0',
-          paddingTop: `${DASHBOARD_GAP}px`,
+          // Cards inside a group wrapper get no top padding — header area provides it
+          paddingTop: insideGroup ? '0' : `${DASHBOARD_GAP}px`,
           paddingBottom: `${DASHBOARD_GAP}px`,
           scrollSnapAlign: 'start',
           overflow: group.type === 'adversary' ? 'visible' : 'hidden',
@@ -167,29 +125,31 @@ const EntityColumns = ({
           showCustomCreator={isEditing}
           onSaveCustomAdversary={isEditing ? handleSaveCustomAdversary : undefined}
           onCancelEdit={isEditing ? handleCancelEdit : undefined}
-          isStockAdversary={isEditing ? (!group.template?.source || group.template?.source !== 'Homebrew') : false}
+          isStockAdversary={isEditing
+            ? (!group.template?.source || group.template?.source !== 'Homebrew')
+            : false}
           onApplyDamage={
             group.type === 'adversary'
               ? (id, damage) => {
-                  const instance = group.instances.find(i => i.id === id)
-                  if (instance) updateAdversary(id, { hp: Math.min(group.template.hpMax || 1, (instance.hp || 0) + damage) })
+                  const inst = group.instances.find(i => i.id === id)
+                  if (inst) updateAdversary(id, { hp: Math.min(group.template.hpMax || 1, (inst.hp || 0) + damage) })
                 }
               : undefined
           }
           onApplyHealing={
             group.type === 'adversary'
               ? (id, healing) => {
-                  const instance = group.instances.find(i => i.id === id)
-                  if (instance) updateAdversary(id, { hp: Math.max(0, (instance.hp || 0) - healing) })
+                  const inst = group.instances.find(i => i.id === id)
+                  if (inst) updateAdversary(id, { hp: Math.max(0, (inst.hp || 0) - healing) })
                 }
               : undefined
           }
           onApplyStressChange={
             group.type === 'adversary'
               ? (id, stress) => {
-                  const instance = group.instances.find(i => i.id === id)
-                  if (instance) updateAdversary(id, {
-                    stress: Math.max(0, Math.min(group.template.stressMax || 6, (instance.stress || 0) + stress)),
+                  const inst = group.instances.find(i => i.id === id)
+                  if (inst) updateAdversary(id, {
+                    stress: Math.max(0, Math.min(group.template.stressMax || 6, (inst.stress || 0) + stress)),
                   })
                 }
               : undefined
@@ -222,20 +182,21 @@ const EntityColumns = ({
                         ? containerWidth - columnWidth - DASHBOARD_GAP
                         : containerWidth
                       const updatedGroups = getEntityGroups()
-                      const groupIndex = updatedGroups.findIndex(g => g.baseName === group.baseName && g.type === 'adversary')
+                      const groupIndex = updatedGroups.findIndex(
+                        g => g.baseName === group.baseName && g.type === 'adversary')
                       if (groupIndex >= 0) {
-                        // Use divider-aware position formula
-                        const cardPosition = cardScrollPosition(groupIndex, updatedGroups, columnWidth)
+                        const cardPosition = DASHBOARD_GAP + groupIndex * (columnWidth + DASHBOARD_GAP)
                         const cardEnd = cardPosition + columnWidth
                         const margin = 10
-                        const isVisible = cardPosition >= currentScroll - margin && cardEnd <= currentScroll + effectiveWidth + margin
+                        const isVisible = cardPosition >= currentScroll - margin &&
+                          cardEnd <= currentScroll + effectiveWidth + margin
                         if (!isVisible) {
                           let targetScroll
                           if (cardEnd > currentScroll + effectiveWidth + margin) {
                             const visibleColumns = Math.round((containerWidth - DASHBOARD_GAP) / (columnWidth + DASHBOARD_GAP))
-                            targetScroll = cardScrollPosition(Math.max(0, groupIndex - visibleColumns + 2), updatedGroups, columnWidth)
+                            targetScroll = (groupIndex - visibleColumns + 2) * (columnWidth + DASHBOARD_GAP)
                           } else {
-                            targetScroll = cardScrollPosition(groupIndex, updatedGroups, columnWidth) - DASHBOARD_GAP
+                            targetScroll = groupIndex * (columnWidth + DASHBOARD_GAP)
                           }
                           smoothScrollTo(Math.max(0, targetScroll), 500)
                         }
@@ -250,24 +211,26 @@ const EntityColumns = ({
               ? () => {
                   const isMinion = group.template?.type === 'Minion'
                   const instancesToRemove = isMinion ? pcCount : 1
-                  const instances = [...group.instances].sort((a, b) => (b.duplicateNumber || 1) - (a.duplicateNumber || 1))
+                  const instances = [...group.instances]
+                    .sort((a, b) => (b.duplicateNumber || 1) - (a.duplicateNumber || 1))
                   if (instances.length === 0) return
                   const isLastInstance = Math.max(0, instances.length - instancesToRemove) === 0
                   const instancesToDelete = instances.slice(0, instancesToRemove)
 
                   if (isLastInstance && !isGrouped) {
-                    const groupIndex = entityGroups.findIndex(g => g.baseName === group.baseName && g.type === 'adversary')
+                    const groupIndex = entityGroups.findIndex(
+                      g => g.baseName === group.baseName && g.type === 'adversary')
                     const isLeftmostColumn = groupIndex === 0
                     let wasAtMaxScroll = false
                     if (scrollContainerRef.current) {
                       const c = scrollContainerRef.current
                       wasAtMaxScroll = Math.abs(c.scrollLeft - (c.scrollWidth - c.clientWidth)) < 1
                     }
-                    // items-array index = flat index + number of dividers before it
-                    const itemsIndex = groupIndex + numDividersBefore(groupIndex, entityGroups)
-                    setRemovingCardSpacer({ baseName: group.baseName, groupIndex: itemsIndex })
+                    setRemovingCardSpacer({ baseName: group.baseName, groupIndex })
                     setSpacerShrinking(false)
-                    if (isLeftmostColumn && scrollContainerRef.current) scrollContainerRef.current.style.scrollSnapType = 'none'
+                    if (isLeftmostColumn && scrollContainerRef.current) {
+                      scrollContainerRef.current.style.scrollSnapType = 'none'
+                    }
                     requestAnimationFrame(() => requestAnimationFrame(() => {
                       if (scrollContainerRef.current) scrollContainerRef.current.offsetHeight
                       instancesToDelete.forEach(inst => deleteAdversary(inst.id))
@@ -278,19 +241,23 @@ const EntityColumns = ({
                           if (wasAtMaxScroll && scrollContainerRef.current) {
                             const startTime = performance.now()
                             const duration = 300
-                            const maintainScroll = () => {
+                            const tick = () => {
                               if (!scrollContainerRef.current) return
-                              scrollContainerRef.current.scrollLeft = scrollContainerRef.current.scrollWidth - scrollContainerRef.current.clientWidth
-                              if (performance.now() - startTime < duration) requestAnimationFrame(maintainScroll)
+                              scrollContainerRef.current.scrollLeft =
+                                scrollContainerRef.current.scrollWidth - scrollContainerRef.current.clientWidth
+                              if (performance.now() - startTime < duration) requestAnimationFrame(tick)
                             }
-                            requestAnimationFrame(maintainScroll)
+                            requestAnimationFrame(tick)
                           }
                           setTimeout(() => {
                             setRemovingCardSpacer(null)
                             setSpacerShrinking(false)
-                            if (isLeftmostColumn && scrollContainerRef.current) scrollContainerRef.current.style.scrollSnapType = 'x mandatory'
+                            if (isLeftmostColumn && scrollContainerRef.current) {
+                              scrollContainerRef.current.style.scrollSnapType = 'x mandatory'
+                            }
                             if (wasAtMaxScroll && scrollContainerRef.current) {
-                              scrollContainerRef.current.scrollLeft = scrollContainerRef.current.scrollWidth - scrollContainerRef.current.clientWidth
+                              scrollContainerRef.current.scrollLeft =
+                                scrollContainerRef.current.scrollWidth - scrollContainerRef.current.clientWidth
                             }
                           }, 300)
                         }, 50)
@@ -307,34 +274,96 @@ const EntityColumns = ({
     )
   }
 
-  // Build the flat items array, injecting vertical dividers between groups
+  const sections = buildSections(entityGroups)
   const items = []
-  let lastGroupName = null
-  let divCount = 0
 
-  entityGroups.forEach((group, index) => {
-    const isFirst = index === 0
-    const isLast = index === entityGroups.length - 1
-    const cssClass = isFirst ? 'dashboard-column dashboard-column--first'
-      : isLast ? 'dashboard-column dashboard-column--last'
-      : 'dashboard-column'
+  sections.forEach((section, sectionIndex) => {
+    const isFirstSection = sectionIndex === 0
+    const isLastSection = sectionIndex === sections.length - 1
 
-    // Inject a divider before each new group boundary (not before the very first group)
-    if (group.groupName && group.groupName !== lastGroupName) {
-      if (lastGroupName !== null) {
-        items.push(<VerticalDivider key={`divider-${group.groupName}-${index}`} groupName={group.groupName} />)
-        divCount++
-      }
-      lastGroupName = group.groupName
-    } else if (!group.groupName) {
-      lastGroupName = null
+    if (section.type === 'grouped') {
+      const { groupName, entries, startFlatIndex } = section
+
+      const cards = entries.map((group, i) => {
+        const isFirst = isFirstSection && i === 0
+        const isLast = isLastSection && i === entries.length - 1
+        const cssClass = isFirst ? 'dashboard-column dashboard-column--first'
+          : isLast ? 'dashboard-column dashboard-column--last'
+          : 'dashboard-column'
+        return renderCardPanel(group, startFlatIndex + i, cssClass, true)
+      })
+
+      items.push(
+        <div
+          key={`group-section-${groupName}-${startFlatIndex}`}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            flexShrink: 0,
+            flexGrow: 0,
+            flex: 'none',
+            position: 'relative',
+          }}
+        >
+          {/* Vertical separator line — in the gap to the left, connects top-to-bottom.
+              Skipped for the very first section (nothing to separate from). */}
+          {!isFirstSection && (
+            <div style={{
+              position: 'absolute',
+              left: -(DASHBOARD_GAP / 2) - 0.5,
+              top: 0,
+              bottom: 0,
+              width: 1,
+              backgroundColor: 'var(--border)',
+              pointerEvents: 'none',
+            }} />
+          )}
+
+          {/* Horizontal header — group label centered, bottom border connects to separator */}
+          <div style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            paddingTop: DASHBOARD_GAP,
+            paddingBottom: 8,
+            borderBottom: '1px solid var(--border)',
+            marginBottom: 0,
+          }}>
+            <span style={{
+              fontSize: '0.72rem',
+              fontWeight: 700,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: 'var(--text-primary)',
+              userSelect: 'none',
+            }}>
+              {groupName}
+            </span>
+          </div>
+
+          {/* Cards row — gap matches scroll container so flat-index math stays correct */}
+          <div style={{
+            display: 'flex',
+            flexDirection: 'row',
+            gap: `${DASHBOARD_GAP}px`,
+            alignItems: 'stretch',
+          }}>
+            {cards}
+          </div>
+        </div>
+      )
+    } else {
+      const { entry: group, flatIndex } = section
+      const cssClass = isFirstSection ? 'dashboard-column dashboard-column--first'
+        : isLastSection ? 'dashboard-column dashboard-column--last'
+        : 'dashboard-column'
+      items.push(renderCardPanel(group, flatIndex, cssClass, false))
     }
-
-    items.push(renderCardPanel(group, index, cssClass, divCount))
   })
 
-  // Spacer for animated card removal (only when groupBy is off so no dividers exist)
-  if (!isGrouped && removingCardSpacer && !items.some(item => item?.key === `spacer-${removingCardSpacer.baseName}`)) {
+  // Spacer for animated card removal (non-grouped mode only)
+  if (!isGrouped && removingCardSpacer &&
+      !items.some(item => item?.key === `spacer-${removingCardSpacer.baseName}`)) {
     const insertIndex = Math.min(removingCardSpacer.groupIndex, items.length)
     items.splice(insertIndex, 0,
       <Panel
@@ -360,7 +389,11 @@ const EntityColumns = ({
     <div ref={scrollContainerRef} className="dashboard-scroll-container" onScroll={onScroll}>
       {items.length > 0 ? items : null}
       {browserOpenAtPosition !== null && (
-        <div style={{ width: `${columnWidth}px`, flexShrink: 0, flexGrow: 0, flex: 'none', height: '100%' }} />
+        <div style={{
+          width: `${columnWidth}px`,
+          flexShrink: 0, flexGrow: 0, flex: 'none',
+          height: '100%',
+        }} />
       )}
     </div>
   )

--- a/src/components/Dashboard/SortGroupPopover.jsx
+++ b/src/components/Dashboard/SortGroupPopover.jsx
@@ -1,24 +1,24 @@
 import React, { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
+import { ArrowUp, ArrowDown } from 'lucide-react'
 
 const SORT_OPTIONS = [
-  { value: 'name-asc',         label: 'Name A–Z'         },
-  { value: 'name-desc',        label: 'Name Z–A'         },
-  { value: 'tier',             label: 'Tier'             },
-  { value: 'type',             label: 'Type'             },
-  { value: 'hp',               label: 'Max HP'           },
-  { value: 'difficulty',       label: 'Difficulty'       },
-  { value: 'atk',              label: 'Attack'           },
-  { value: 'threshold-major',  label: 'Damage threshold' },
+  { value: 'name',       label: 'Name'             },
+  { value: 'tier',       label: 'Tier'             },
+  { value: 'type',       label: 'Type'             },
+  { value: 'hp',         label: 'Max HP'           },
+  { value: 'difficulty', label: 'Difficulty'       },
+  { value: 'atk',        label: 'Attack'           },
+  { value: 'threshold',  label: 'Damage threshold' },
 ]
 
 const GROUP_OPTIONS = [
-  { value: 'none', label: 'None'  },
-  { value: 'type', label: 'Type'  },
-  { value: 'tier', label: 'Tier'  },
+  { value: 'none', label: 'None' },
+  { value: 'type', label: 'Type' },
+  { value: 'tier', label: 'Tier' },
 ]
 
-const SortGroupPopover = ({ anchorRef, placement, sortBy, groupBy, onSortBy, onGroupBy, onClose }) => {
+const SortGroupPopover = ({ anchorRef, placement, sortBy, sortDir, groupBy, onSortBy, onGroupBy, onClose }) => {
   const popoverRef = useRef(null)
 
   useEffect(() => {
@@ -38,14 +38,12 @@ const SortGroupPopover = ({ anchorRef, placement, sortBy, groupBy, onSortBy, onG
     return () => document.removeEventListener('keydown', handleKey)
   }, [onClose])
 
-  // Position next to the anchor button
   const getPosition = () => {
     if (!anchorRef.current) return {}
     const rect = anchorRef.current.getBoundingClientRect()
     if (placement === 'right') {
       return { right: `calc(100vw - ${rect.left}px + 6px)`, top: `${rect.top}px` }
     }
-    // bottom rail
     return { left: `${rect.left}px`, bottom: `calc(100vh - ${rect.top}px + 6px)` }
   }
 
@@ -71,6 +69,7 @@ const SortGroupPopover = ({ anchorRef, placement, sortBy, groupBy, onSortBy, onG
     color: selected ? 'var(--purple)' : 'var(--text-primary)',
     fontSize: '0.85rem',
     userSelect: 'none',
+    justifyContent: 'space-between',
   })
 
   const dot = (selected) => ({
@@ -94,7 +93,7 @@ const SortGroupPopover = ({ anchorRef, placement, sortBy, groupBy, onSortBy, onG
         borderRadius: '10px',
         boxShadow: '0 8px 32px rgba(0,0,0,0.35)',
         padding: '1rem',
-        minWidth: '180px',
+        minWidth: '190px',
         display: 'flex',
         flexDirection: 'column',
         gap: '1rem',
@@ -102,16 +101,26 @@ const SortGroupPopover = ({ anchorRef, placement, sortBy, groupBy, onSortBy, onG
     >
       <div>
         <div style={sectionLabel}>Sort by</div>
-        {SORT_OPTIONS.map(({ value, label }) => (
-          <div
-            key={value}
-            style={optRow(sortBy === value)}
-            onClick={() => onSortBy(value)}
-          >
-            <div style={dot(sortBy === value)} />
-            {label}
-          </div>
-        ))}
+        {SORT_OPTIONS.map(({ value, label }) => {
+          const selected = sortBy === value
+          return (
+            <div
+              key={value}
+              style={optRow(selected)}
+              onClick={() => onSortBy(value)}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <div style={dot(selected)} />
+                {label}
+              </div>
+              {selected && (
+                sortDir === 'asc'
+                  ? <ArrowUp size={13} strokeWidth={2.2} />
+                  : <ArrowDown size={13} strokeWidth={2.2} />
+              )}
+            </div>
+          )
+        })}
       </div>
       <div style={{ borderTop: '1px solid var(--border)', paddingTop: '0.75rem' }}>
         <div style={sectionLabel}>Group by</div>
@@ -121,8 +130,10 @@ const SortGroupPopover = ({ anchorRef, placement, sortBy, groupBy, onSortBy, onG
             style={optRow(groupBy === value)}
             onClick={() => onGroupBy(value)}
           >
-            <div style={dot(groupBy === value)} />
-            {label}
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+              <div style={dot(groupBy === value)} />
+              {label}
+            </div>
           </div>
         ))}
       </div>

--- a/src/components/Dashboard/hooks/useDashboardSortGroup.js
+++ b/src/components/Dashboard/hooks/useDashboardSortGroup.js
@@ -60,8 +60,20 @@ function getSortValue(group, sortBy) {
   }
 }
 
-export function applySort(adversaryGroups, sortBy, sortDir) {
+export function applySort(adversaryGroups, sortBy, sortDir, groupBy = 'none') {
   return [...adversaryGroups].sort((a, b) => {
+    // When grouping is active, sort by the group field first so same-group
+    // entries are always adjacent — sortBy acts as the secondary (within-group) key.
+    if (groupBy !== 'none') {
+      const groupField = groupBy === 'tier' ? 'tier' : 'type'
+      if (groupField !== sortBy) {
+        const ag = getSortValue(a, groupField)
+        const bg = getSortValue(b, groupField)
+        const gcmp = typeof ag === 'string' ? ag.localeCompare(bg) : ag - bg
+        if (gcmp !== 0) return gcmp
+      }
+    }
+    // Primary (or secondary when grouping) sort
     const av = getSortValue(a, sortBy)
     const bv = getSortValue(b, sortBy)
     let cmp

--- a/src/components/Dashboard/hooks/useDashboardSortGroup.js
+++ b/src/components/Dashboard/hooks/useDashboardSortGroup.js
@@ -4,58 +4,73 @@ import { useState, useEffect } from 'react'
 const STORAGE_KEY = 'daggerheart-dashboard-sort-group'
 
 const DEFAULTS = {
-  sortBy: 'name-asc',
+  sortBy: 'name',
+  sortDir: 'asc',
   groupBy: 'none',
 }
 
 export function useDashboardSortGroup() {
   const [settings, setSettings] = useState(() => {
     const stored = readFromStorage(STORAGE_KEY)
-    return stored ? { ...DEFAULTS, ...stored } : DEFAULTS
+    if (!stored) return DEFAULTS
+    // Migrate old format (sortBy: 'name-asc') to new format
+    if (stored.sortBy && stored.sortBy.includes('-')) {
+      const [field, dir] = stored.sortBy.split('-')
+      return { ...DEFAULTS, sortBy: field, sortDir: dir || 'asc', groupBy: stored.groupBy || 'none' }
+    }
+    return { ...DEFAULTS, ...stored }
   })
 
   useEffect(() => {
     writeToStorage(STORAGE_KEY, settings)
   }, [settings])
 
-  const setSortBy = (sortBy) => setSettings(s => ({ ...s, sortBy }))
+  // Clicking the same field toggles direction; clicking a new field starts ascending
+  const setSortBy = (field) => setSettings(s => ({
+    ...s,
+    sortBy: field,
+    sortDir: s.sortBy === field ? (s.sortDir === 'asc' ? 'desc' : 'asc') : 'asc',
+  }))
+
   const setGroupBy = (groupBy) => setSettings(s => ({ ...s, groupBy }))
 
   return { ...settings, setSortBy, setGroupBy }
 }
 
-// Sort comparators for adversary groups (groups have template fields at top level)
+const SORT_FIELD_KEY = {
+  name: 'baseName',
+  tier: 'tier',
+  type: 'type',
+  hp: 'hpMax',
+  difficulty: 'difficulty',
+  atk: 'atk',
+  threshold: null, // handled specially
+}
+
 function getSortValue(group, sortBy) {
   switch (sortBy) {
-    case 'name-asc':
-    case 'name-desc':
-      return (group.baseName || '').toLowerCase()
-    case 'tier':
-      return group.tier ?? 0
-    case 'type':
-      return (group.type || '').toLowerCase()
-    case 'hp':
-      return group.hpMax ?? 0
-    case 'difficulty':
-      return group.difficulty ?? 0
-    case 'atk':
-      return group.atk ?? 0
-    case 'threshold-major':
-      return group.thresholds?.major ?? group.damageThreshold ?? 0
-    default:
-      return (group.baseName || '').toLowerCase()
+    case 'name': return (group.baseName || '').toLowerCase()
+    case 'tier': return group.tier ?? 0
+    case 'type': return (group.type || '').toLowerCase()
+    case 'hp': return group.hpMax ?? 0
+    case 'difficulty': return group.difficulty ?? 0
+    case 'atk': return group.atk ?? 0
+    case 'threshold': return group.thresholds?.major ?? group.damageThreshold ?? 0
+    default: return (group.baseName || '').toLowerCase()
   }
 }
 
-export function applySort(adversaryGroups, sortBy) {
+export function applySort(adversaryGroups, sortBy, sortDir) {
   return [...adversaryGroups].sort((a, b) => {
     const av = getSortValue(a, sortBy)
     const bv = getSortValue(b, sortBy)
+    let cmp
     if (typeof av === 'string' && typeof bv === 'string') {
-      const cmp = av.localeCompare(bv)
-      return sortBy === 'name-desc' ? -cmp : cmp
+      cmp = av.localeCompare(bv)
+    } else {
+      cmp = av - bv
     }
-    return sortBy === 'name-desc' ? bv - av : av - bv
+    return sortDir === 'desc' ? -cmp : cmp
   })
 }
 

--- a/src/components/Dashboard/hooks/useEntityGroups.js
+++ b/src/components/Dashboard/hooks/useEntityGroups.js
@@ -5,6 +5,10 @@ import { applySort, getGroupLabel } from './useDashboardSortGroup'
  * Combines adversary groups (already grouped in state) with countdowns into
  * a single list for the rendering layer to treat each as a column.
  * Applies sort and optional grouping to adversary groups.
+ *
+ * When groupBy is active, every adversary entry carries a `groupName` string
+ * so EntityColumns can identify and wrap same-group runs into a single row
+ * with a shared sticky header above all the cards.
  */
 export const useEntityGroups = (adversaryGroups, countdowns, sortBy = 'name', sortDir = 'asc', groupBy = 'none') => {
   const getEntityGroups = useCallback(() => {
@@ -12,24 +16,15 @@ export const useEntityGroups = (adversaryGroups, countdowns, sortBy = 'name', so
 
     const sortedAdversaryGroups = applySort(adversaryGroups, sortBy, sortDir)
 
-    let lastGroupLabel = null
-
     sortedAdversaryGroups.forEach((group) => {
-      let groupLabel = null
-      if (groupBy !== 'none') {
-        const label = getGroupLabel(group, groupBy)
-        if (label !== lastGroupLabel) {
-          groupLabel = label
-          lastGroupLabel = label
-        }
-      }
+      const groupName = groupBy !== 'none' ? getGroupLabel(group, groupBy) : null
 
       groups.push({
         type: 'adversary',
         baseName: group.baseName,
         template: group,
         instances: group.instances,
-        groupLabel,
+        groupName,
       })
     })
 
@@ -39,6 +34,7 @@ export const useEntityGroups = (adversaryGroups, countdowns, sortBy = 'name', so
         baseName: countdown.name,
         template: countdown,
         instances: [countdown],
+        groupName: null,
       })
     })
 

--- a/src/components/Dashboard/hooks/useEntityGroups.js
+++ b/src/components/Dashboard/hooks/useEntityGroups.js
@@ -14,7 +14,7 @@ export const useEntityGroups = (adversaryGroups, countdowns, sortBy = 'name', so
   const getEntityGroups = useCallback(() => {
     const groups = []
 
-    const sortedAdversaryGroups = applySort(adversaryGroups, sortBy, sortDir)
+    const sortedAdversaryGroups = applySort(adversaryGroups, sortBy, sortDir, groupBy)
 
     sortedAdversaryGroups.forEach((group) => {
       const groupName = groupBy !== 'none' ? getGroupLabel(group, groupBy) : null

--- a/src/components/Dashboard/hooks/useEntityGroups.js
+++ b/src/components/Dashboard/hooks/useEntityGroups.js
@@ -6,23 +6,20 @@ import { applySort, getGroupLabel } from './useDashboardSortGroup'
  * a single list for the rendering layer to treat each as a column.
  * Applies sort and optional grouping to adversary groups.
  */
-export const useEntityGroups = (adversaryGroups, countdowns, sortBy = 'name-asc', groupBy = 'none') => {
+export const useEntityGroups = (adversaryGroups, countdowns, sortBy = 'name', sortDir = 'asc', groupBy = 'none') => {
   const getEntityGroups = useCallback(() => {
     const groups = []
 
-    const sortedAdversaryGroups = applySort(adversaryGroups, sortBy)
+    const sortedAdversaryGroups = applySort(adversaryGroups, sortBy, sortDir)
 
     let lastGroupLabel = null
 
     sortedAdversaryGroups.forEach((group) => {
+      let groupLabel = null
       if (groupBy !== 'none') {
         const label = getGroupLabel(group, groupBy)
         if (label !== lastGroupLabel) {
-          groups.push({
-            type: 'separator',
-            baseName: `separator-${label}-${groups.length}`,
-            label,
-          })
+          groupLabel = label
           lastGroupLabel = label
         }
       }
@@ -32,6 +29,7 @@ export const useEntityGroups = (adversaryGroups, countdowns, sortBy = 'name-asc'
         baseName: group.baseName,
         template: group,
         instances: group.instances,
+        groupLabel,
       })
     })
 
@@ -45,7 +43,7 @@ export const useEntityGroups = (adversaryGroups, countdowns, sortBy = 'name-asc'
     })
 
     return groups
-  }, [adversaryGroups, countdowns, sortBy, groupBy])
+  }, [adversaryGroups, countdowns, sortBy, sortDir, groupBy])
 
   const entityGroups = useMemo(() => getEntityGroups(), [getEntityGroups])
 


### PR DESCRIPTION
## Summary

Follow-up to #43 based on feedback.

- **Group labels above cards**: instead of a vertical divider column between groups, the group label now appears as a small uppercase header directly above the first card in each group — less disruptive to the scroll layout
- **Sort direction toggle**: all sort options are now a single entry. Clicking an unselected option selects it (ascending). Clicking the active option toggles the direction. An up/down arrow next to the selected option shows the current direction.
- Migrates persisted sort state from `sortBy: 'name-asc'` strings to `{ sortBy: 'name', sortDir: 'asc' }` (old format auto-migrates on first load)

## Test plan

- [ ] Group by Type → label "Skulk", "Ranged", etc. appears above the first card in each group, not as a separate column
- [ ] Click "Tier" in Sort by → cards sort tier ascending, arrow-up icon appears next to Tier
- [ ] Click "Tier" again → sort reverses to descending, arrow-down icon appears
- [ ] Click "Name" → switches to name sort ascending; Tier arrow disappears
- [ ] Reload → settings restore correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)